### PR TITLE
allow use of SSH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     unzip \
     wget \
     zip \
+    openssh-client \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install --upgrade pip
 RUN pip install --upgrade setuptools

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # codebuild-terraform-ci-cd-image
 Docker image for Terrafocm CI/CD CodeBuild builds
+
+## Prerequisites to using this image
+
+* Github app private key
+  - Either this or both of this and a Github ssh private key must be set
+  - Github app private key must be set in your AWS ssm with the key 
+    `/tvlk-secret/terraform-ci-cd/terraform-ci-cd/github-app-private-key`
+
+* Github app ssh key
+  - Either this or both of this and a Github app private key must be set
+  - This ssh private key must be set in your AWS ssm with the key 
+    `/tvlk-secret/terraform-ci-cd/terraform-ci-cd/github-ssh-private-key`
+  - The public key portion must be added to a user with access to all of the 
+    git repositories mentioned in the projects you are trying to build
+  - The recommendation is to create a github 
+    [machine user](https://developer.github.com/v3/guides/managing-deploy-keys/#machine-users),
+    add the user to the github Traveloka organization and add this ssh public 
+    key to it

--- a/scripts/cd-setup-env-var.sh
+++ b/scripts/cd-setup-env-var.sh
@@ -1,11 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -e
+
 # Set CD Environment Variables:
 # 1. OWNER_REPO             ${owner name}/${repo name}
 # 2. GIT_COMMIT_ID          Current Commit ID
 # 3. GIT_MASTER_COMMIT_ID   Previous Commit ID
 # 4. GITHUB_TOKEN           Github token for Github authentication
 # 5. GIT_ASKPASS            Command which called by git command to authenticate using Github token
-# 6. PR_ID                  Github Pull Request ID from Github API
+# 6. ~/.ssh/id_rsa          Sets ssh private key for ssh git clones
+# 7. PR_ID                  Github Pull Request ID from Github API
 
 export OWNER_REPO="$(git config --get remote.origin.url | sed 's/^https:\/\/github.com\///; s/.git$//')"
 echo "OWNER_REPO=${OWNER_REPO}"
@@ -16,10 +20,26 @@ echo "GIT_MASTER_COMMIT_ID=${GIT_MASTER_COMMIT_ID}"
 
 # Get Temporary Github Token By using Github app private key from AWS Parameter Store
 gen-github-token.py
-export GITHUB_TOKEN=$(cat GITHUB_TOKEN)
-echo "GITHUB_TOKEN is set"
-export GIT_ASKPASS="parse-git-auth.sh"
-echo "GIT_ASKPASS=${GIT_ASKPASS}"
+if [ -f "GITHUB_TOKEN" ]; then
+    export GITHUB_TOKEN=$(cat GITHUB_TOKEN)
+    echo "GITHUB_TOKEN is set"
+	export GIT_ASKPASS="parse-git-auth.sh"
+	echo "GIT_ASKPASS=${GIT_ASKPASS}"
+fi
+
+# Set ssh private key, if it exists
+setup-github-ssh.py
+if [ -f "~/.ssh/id_rsa" ]; then
+    export GITHUB_TOKEN=$(cat GITHUB_TOKEN)
+    echo "Github ssh private is set"
+fi
+
+# either ssh private key or app private key must be present for git clone to work
+# if both exists, then it depends on how the source is written to use either
+if [ ! -f "GITHUB_TOKEN" -a  ! -f "~/.ssh/id_rsa" ]; then
+    echo "Either Github app private key or ssh private key must be set!"
+    exit 1
+fi
 
 # Get PR_ID from Github API
 export PR_ID="$(curl -H "Authorization: token $GITHUB_TOKEN" -X GET https://api.github.com/search/issues?q=${GIT_COMMIT_ID}+is:merged\&sort=updated\&order=desc | jq -r '.items[0].number')"

--- a/scripts/cd-setup-env-var.sh
+++ b/scripts/cd-setup-env-var.sh
@@ -30,7 +30,6 @@ fi
 # Set ssh private key, if it exists
 setup-github-ssh.py
 if [ -f "~/.ssh/id_rsa" ]; then
-    export GITHUB_TOKEN=$(cat GITHUB_TOKEN)
     echo "Github ssh private is set"
 fi
 

--- a/scripts/cd-setup-env-var.sh
+++ b/scripts/cd-setup-env-var.sh
@@ -23,8 +23,8 @@ gen-github-token.py
 if [ -f "GITHUB_TOKEN" ]; then
     export GITHUB_TOKEN=$(cat GITHUB_TOKEN)
     echo "GITHUB_TOKEN is set"
-	export GIT_ASKPASS="parse-git-auth.sh"
-	echo "GIT_ASKPASS=${GIT_ASKPASS}"
+    export GIT_ASKPASS="parse-git-auth.sh"
+    echo "GIT_ASKPASS=${GIT_ASKPASS}"
 fi
 
 # Set ssh private key, if it exists

--- a/scripts/cd-setup-env-var.sh
+++ b/scripts/cd-setup-env-var.sh
@@ -30,7 +30,7 @@ fi
 # Set ssh private key, if it exists
 setup-github-ssh.py
 if [ -f "~/.ssh/id_rsa" ]; then
-    echo "Github ssh private is set"
+    echo "Github ssh private key is set"
 fi
 
 # either ssh private key or app private key must be present for git clone to work

--- a/scripts/ci-setup-env-var.sh
+++ b/scripts/ci-setup-env-var.sh
@@ -1,11 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -e
+
 # Set CI Environment Variables:
 # 1. OWNER_REPO             ${owner name}/${repo name}
 # 2. PR_ID                  Github Pull Request ID
 # 3. GIT_MASTER_COMMIT_ID   Latest master commit which fetched by current build
 # 4. GITHUB_TOKEN           Github token for Github authentication
 # 5. GIT_ASKPASS            Command which called by git command to authenticate using Github token
-# 6. LATEST_COMMIT_APPLY    Commit that currently applied on infra.
+# 6. ~/.ssh/id_rsa          Sets ssh private key for ssh git clones
+# 7. LATEST_COMMIT_APPLY    Commit that currently applied on infra.
 
 export OWNER_REPO="$(git config --get remote.origin.url | sed 's/^https:\/\/github.com\///; s/.git$//')"
 echo "OWNER_REPO=${OWNER_REPO}"
@@ -16,12 +20,29 @@ echo "GIT_MASTER_COMMIT_ID=${GIT_MASTER_COMMIT_ID}"
 
 # Get Temporary Github Token By using Github app private key from AWS Parameter Store
 gen-github-token.py
-export GITHUB_TOKEN=$(cat GITHUB_TOKEN)
-echo "GITHUB_TOKEN is set"
-export GIT_ASKPASS="parse-git-auth.sh"
-echo "GIT_ASKPASS=${GIT_ASKPASS}"
+if [ -f "GITHUB_TOKEN" ]; then
+    export GITHUB_TOKEN=$(cat GITHUB_TOKEN)
+    echo "GITHUB_TOKEN is set"
+	export GIT_ASKPASS="parse-git-auth.sh"
+	echo "GIT_ASKPASS=${GIT_ASKPASS}"
+fi
+
+# Set ssh private key, if it exists
+setup-github-ssh.py
+if [ -f "~/.ssh/id_rsa" ]; then
+    export GITHUB_TOKEN=$(cat GITHUB_TOKEN)
+    echo "Github ssh private is set"
+fi
+
+# either ssh private key or app private key must be present for git clone to work
+# if both exists, then it depends on how the source is written to use either
+if [ ! -f "GITHUB_TOKEN" -a  ! -f "~/.ssh/id_rsa" ]; then
+    echo "Either Github app private key or ssh private key must be set!"
+    exit 1
+fi
 
 # Get latest-commit-apply from artifact S3 Bucket
-aws s3 cp s3://${ARTIFACT_BUCKET}/latest-commit-apply latest-commit-apply
+# Ignore error if latest-commit-apply does not exist
+aws s3 cp s3://${ARTIFACT_BUCKET}/latest-commit-apply latest-commit-apply || true
 export LATEST_COMMIT_APPLY="$(cat latest-commit-apply)"
 echo "LATEST_COMMIT_APPLY=${LATEST_COMMIT_APPLY}"

--- a/scripts/ci-setup-env-var.sh
+++ b/scripts/ci-setup-env-var.sh
@@ -30,7 +30,6 @@ fi
 # Set ssh private key, if it exists
 setup-github-ssh.py
 if [ -f "~/.ssh/id_rsa" ]; then
-    export GITHUB_TOKEN=$(cat GITHUB_TOKEN)
     echo "Github ssh private is set"
 fi
 

--- a/scripts/ci-setup-env-var.sh
+++ b/scripts/ci-setup-env-var.sh
@@ -23,8 +23,8 @@ gen-github-token.py
 if [ -f "GITHUB_TOKEN" ]; then
     export GITHUB_TOKEN=$(cat GITHUB_TOKEN)
     echo "GITHUB_TOKEN is set"
-	export GIT_ASKPASS="parse-git-auth.sh"
-	echo "GIT_ASKPASS=${GIT_ASKPASS}"
+    export GIT_ASKPASS="parse-git-auth.sh"
+    echo "GIT_ASKPASS=${GIT_ASKPASS}"
 fi
 
 # Set ssh private key, if it exists

--- a/scripts/ci-setup-env-var.sh
+++ b/scripts/ci-setup-env-var.sh
@@ -30,7 +30,7 @@ fi
 # Set ssh private key, if it exists
 setup-github-ssh.py
 if [ -f "~/.ssh/id_rsa" ]; then
-    echo "Github ssh private is set"
+    echo "Github ssh private key is set"
 fi
 
 # either ssh private key or app private key must be present for git clone to work

--- a/scripts/setup-github-ssh.py
+++ b/scripts/setup-github-ssh.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+import boto3
+
+ssm_key = "/tvlk-secret/terraform-ci-cd/terraform-ci-cd/github-ssh-private-key"
+print "Looking for ssh private key at " + ssm_key
+
+client = boto3.client('ssm')
+parameter_store = client.get_parameter(
+    Name=ssm_key,
+    WithDecryption=True
+)
+
+github_ssh_private_key = parameter_store["Parameter"]["Value"]
+
+# ignore setting ssh private key if there is no ssh private key set in the SSM
+if not github_ssh_private_key:
+    print "There is no ssh private key set"
+    sys.exit(0)
+
+
+import os
+
+id_rsa = os.path.expanduser('~/.ssh/id_rsa')
+
+if not os.path.exists(os.path.dirname(id_rsa)):
+	os.makedirs(os.path.dirname(id_rsa))
+
+with open(id_rsa, "w") as f:
+    f.write(github_ssh_private_key)
+
+os.chmod(id_rsa, 0600)
+
+known_hosts = os.path.expanduser('~/.ssh/known_hosts')
+os.system("ssh-keyscan github.com >> " + known_hosts)

--- a/scripts/setup-github-ssh.py
+++ b/scripts/setup-github-ssh.py
@@ -24,7 +24,7 @@ import os
 id_rsa = os.path.expanduser('~/.ssh/id_rsa')
 
 if not os.path.exists(os.path.dirname(id_rsa)):
-	os.makedirs(os.path.dirname(id_rsa))
+    os.makedirs(os.path.dirname(id_rsa))
 
 with open(id_rsa, "w") as f:
     f.write(github_ssh_private_key)


### PR DESCRIPTION
Changes:

* Dockerfile
  - Install ssh client
* README
  - Added notes on private key requirements
* `scripts/gen-github-token.py`
  - Made github app private key optional
* `scripts/setup-github-ssh.py`
  - Optionally read github ssh private key from ssm
  - Hardcoded ssm key, `/tvlk-secret/terraform-ci-cd/terraform-ci-cd/github-ssh-private-key`
* `scripts/ci-setup-env-var.sh`
  - Added `set -e`, which stops script from running if there is an error with 1 of the commands
  - Check that either github app private key or github ssh private key must exists
* `scripts/cd-setup-env-var.sh`
  - Same changes as ci scripts