### PR TITLE
Bug/different absolute paths for ci and cd

### DIFF
--- a/scripts/cd-do-terraform-apply.sh
+++ b/scripts/cd-do-terraform-apply.sh
@@ -1,15 +1,32 @@
 #!/bin/bash
 # Do Terraform Apply based on TF_WORKING_DIR and set TF_WORKING_DIR env var
 
+set -e
+
+CD_PWD=$PWD
+
 cd artifact
 echo "metadata.json"
 cat metadata.json
 
 # Set TF_WORKING_DIR env var from metadata.json
 export TF_WORKING_DIR="$(cat metadata.json | jq -r '.TF_WORKING_DIR')"
+CI_PWD="$(cat metadata.json | jq -r '.CI_PWD')"
 
 if [ "$TF_WORKING_DIR" != "" ]; then
+	ls -la
+
+	echo "sed -i s:$CI_PWD:$CD_PWD:g terraform.tfplan"
+
+	# https://github.com/hashicorp/terraform/issues/8204
+    # https://github.com/hashicorp/terraform/issues/7613
+    # We need to correct the absolute paths in the tfplan first
+    sed -i -e "s:$CI_PWD:$CD_PWD:g" terraform.tfplan
+
+	ls -la
+
     cd $TF_WORKING_DIR
+
     # Do Terraform Apply from terraform.tfplan
     terraform init -no-color
     terraform apply ${OLDPWD}/terraform.tfplan -no-color

--- a/scripts/cd-do-terraform-apply.sh
+++ b/scripts/cd-do-terraform-apply.sh
@@ -14,16 +14,14 @@ export TF_WORKING_DIR="$(cat metadata.json | jq -r '.TF_WORKING_DIR')"
 CI_PWD="$(cat metadata.json | jq -r '.CI_PWD')"
 
 if [ "$TF_WORKING_DIR" != "" ]; then
-	ls -la
+    ls -la
 
-	echo "sed -i s:$CI_PWD:$CD_PWD:g terraform.tfplan"
+    echo "sed -i s:$CI_PWD:$CD_PWD:g terraform.tfplan"
 
-	# https://github.com/hashicorp/terraform/issues/8204
+    # https://github.com/hashicorp/terraform/issues/8204
     # https://github.com/hashicorp/terraform/issues/7613
     # We need to correct the absolute paths in the tfplan first
     sed -i -e "s:$CI_PWD:$CD_PWD:g" terraform.tfplan
-
-	ls -la
 
     cd $TF_WORKING_DIR
 

--- a/scripts/cd-get-plan-artifact.sh
+++ b/scripts/cd-get-plan-artifact.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Get Plan Artifact based on GIT_MASTER_COMMIT_ID and PR_ID
 
+set -e
+
 # Download Plan Artifact from S3 Bucket
 aws s3 cp s3://${ARTIFACT_BUCKET}/plan/${GIT_MASTER_COMMIT_ID}-${PR_ID}.zip ${GIT_MASTER_COMMIT_ID}-${PR_ID}.zip
 # Setup Working directory

--- a/scripts/ci-create-plan-artifact.sh
+++ b/scripts/ci-create-plan-artifact.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 # Create Plan Artifact
 
 # Copy Terraform working directory
@@ -10,7 +13,8 @@ fi
 jq -n "{
     PR_ID: \"$PR_ID\",
     GIT_MASTER_COMMIT_ID: \"$GIT_MASTER_COMMIT_ID\",
-    TF_WORKING_DIR: \"$TF_WORKING_DIR\"
+    TF_WORKING_DIR: \"$TF_WORKING_DIR\",
+    PWD: \"$PWD\"
 }" > artifact/metadata.json
 
 # Zip artifact folder

--- a/scripts/ci-create-plan-artifact.sh
+++ b/scripts/ci-create-plan-artifact.sh
@@ -14,7 +14,7 @@ jq -n "{
     PR_ID: \"$PR_ID\",
     GIT_MASTER_COMMIT_ID: \"$GIT_MASTER_COMMIT_ID\",
     TF_WORKING_DIR: \"$TF_WORKING_DIR\",
-    PWD: \"$PWD\"
+    CI_PWD: \"$PWD\"
 }" > artifact/metadata.json
 
 # Zip artifact folder

--- a/scripts/ci-do-terraform-plan.sh
+++ b/scripts/ci-do-terraform-plan.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-# Do Terraform Plan on TF_WORKING_DIR and store it on artifact folder
 
+set -e
+
+# Do Terraform Plan on TF_WORKING_DIR and store it on artifact folder
 mkdir -p artifact
 if [ "$TF_WORKING_DIR" != "" ]; then
     cd $TF_WORKING_DIR

--- a/scripts/ci-upload-plan-artifact.sh
+++ b/scripts/ci-upload-plan-artifact.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 # Upload Plan Artifact to S3 Bucket
 
+set -e
+
 aws s3 cp ${GIT_MASTER_COMMIT_ID}-${PR_ID}.zip s3://${ARTIFACT_BUCKET}/plan/${GIT_MASTER_COMMIT_ID}-${PR_ID}.zip


### PR DESCRIPTION
## Problem

When the terraform uses local paths resources or data, the CD will fail with errors stating that the path defined in the CI plan does not exist.

This is because the full absolute path is hard coded into the terraform plan by terraform itself. The following are the issues that track this problem (there is no acceptable solution yet):

https://github.com/hashicorp/terraform/issues/8204
https://github.com/hashicorp/terraform/issues/7613

`resource "local_file"` and `data "external"` are the most affected by this.

## Solution

The workaround is to store the CI pwd in the metadata.json, and replace the CI pwd with the CD pwd during CD.

## Changes

1. Added `CI_PWD=$PWD` to `metadata.json` in `ci-create-plan-artifact.sh`
2. Set `CD_PWD=$PWD` in `cd-do-terraform-apply.sh`
3. Replace all `CI_PWD` in plan with `CD_PWD`
4. Added `set -e` to scripts so that the build will actually fail if the scripts fail