### PR TITLE
Modify Notify plan message to using collapsible format

### DIFF
--- a/scripts/ci-notify-plan-artifact-to-github-pr.py
+++ b/scripts/ci-notify-plan-artifact-to-github-pr.py
@@ -17,7 +17,7 @@ f = open("artifact/metadata.json", "r")
 metadata = f.read()
 headers = {"Authorization": "token " + git_token}
 json = {
-    "body": "metadata.json\n```json\n" + metadata + "```\nterraform.tfplan\n```hcl\n" + tf_plan + "```\n"
+    "body": "<details><summary>metadata.json</summary>\n\n```json\n" + metadata + "\n```\n</details><details><summary>terraform.tfplan</summary>\n\n```hcl\n" + tf_plan + "\n```\n"
 }
 
 r = requests.post('https://api.github.com/repos/' + owner_repo +


### PR DESCRIPTION
As describe https://29022131.atlassian.net/browse/CTD-153
ci message will bloat PR comment if we update the PR or the plan itself contain long long plan.

After reformating, the message should look like screenshot below
![image](https://user-images.githubusercontent.com/19589587/69327380-08ba5d80-0c80-11ea-8c77-474b5ff62f69.png)
