### PR TITLE
Add alternative ci_check script, output terraform apply to file, add script to notify apply result to github

### DIFF
--- a/scripts/cd-do-terraform-apply.sh
+++ b/scripts/cd-do-terraform-apply.sh
@@ -25,7 +25,7 @@ if [ "$TF_WORKING_DIR" != "" ]; then
 
     # Do Terraform Apply from terraform.tfplan
     terraform init -no-color
-    terraform apply ${OLDPWD}/terraform.tfplan -no-color
+    terraform apply ${OLDPWD}/terraform.tfplan -no-color | tee ${CD_PWD}/apply_output.txt
 
     rm -rf .terraform
     cd -

--- a/scripts/cd-notify-apply-result-to-github.py
+++ b/scripts/cd-notify-apply-result-to-github.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# Notify Plan Artifact to Github Pull Request
+
+import sys
+import requests
+import os
+
+apply_f = open("apply_output.txt", "r")
+apply_result = apply_f.read()
+
+git_token = os.environ["GITHUB_TOKEN"]
+owner_repo = os.environ["OWNER_REPO"]
+pr_id = os.environ["PR_ID"]
+
+f = open("artifact/metadata.json", "r")
+metadata = f.read()
+headers = {"Authorization": "token " + git_token}
+json = {
+    "body": "<details><summary>metadata.json</summary>\n\n```json\n" + metadata + "\n```\n</details><details><summary>apply result</summary>\n\n```hcl\n" + apply_result
+ + "\n```\n"
+}
+
+r = requests.post('https://api.github.com/repos/' + owner_repo +
+                  '/issues/' + pr_id + '/comments', headers=headers, json=json)
+print r.json

--- a/scripts/ci-check-no-apply.py
+++ b/scripts/ci-check-no-apply.py
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Check CI prerequisites to do Terraform commands and set env var TF_WORKING_DIR
+
+# Check if current commit is based on latest master commit on repo
+git merge-base --is-ancestor origin/master HEAD
+if [ $? -ne 0 ]; then
+    echo "Error: Feature branch is behind the latest master branch commit. Please rebase/add merge commit from master to your feature branch"
+    exit 1
+fi
+
+# Check if latest master commit on repo and commit on current infra state on S3 bucket are equal/same
+if [ $GIT_MASTER_COMMIT_ID != $LATEST_COMMIT_APPLY ]; then
+    echo "Warning: Git commit on origin/master($GIT_MASTER_COMMIT_ID) and latest-commit-apply($LATEST_COMMIT_APPLY) on S3 aren't equal"
+fi
+
+# Set env var TF_WORKING_DIR
+export TF_WORKING_DIR="$(git diff origin/master --name-only | grep '\.tf$\|\.tpl$' | sed 's/\/[^/]\+\.tf$\|\/[^/]\+\.tpl$//g' | uniq)"
+echo "Folders contain tf file changes:
+$TF_WORKING_DIR
+"
+
+# Check if only one folder contains tf files changes
+if [ $(echo "$TF_WORKING_DIR" | wc -l) -gt 1 ]; then
+    echo "Error: Multiple folder contain tf file changes"
+    exit 1
+fi
+if [ ! -d "$TF_WORKING_DIR" ]; then
+    echo "$TF_WORKING_DIR folder is deleted. Will do nothing"
+    export TF_WORKING_DIR=""
+fi

--- a/scripts/ci-check-no-cd-check.py
+++ b/scripts/ci-check-no-cd-check.py
@@ -8,7 +8,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-# Check if latest master commit on repo and commit on current infra state on S3 bucket are equal/same
+# Warn if last applied terraform is not master latest commit
 if [ $GIT_MASTER_COMMIT_ID != $LATEST_COMMIT_APPLY ]; then
     echo "Warning: Git commit on origin/master($GIT_MASTER_COMMIT_ID) and latest-commit-apply($LATEST_COMMIT_APPLY) on S3 aren't equal"
 fi


### PR DESCRIPTION
1. Add ci-check-no-cd-check.sh, this script is ci-check.sh but without the latest-commit-apply check (it only warns in the log)
2. Add cd-notify-apply-result-to-github.sh which uploads output of terraform plan to the PR
3. put result of terraform apply to a file in cd-do-terraform-apply.sh