### PR TITLE
Install terraform latest version to prevent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN python -m pip install --upgrade pip && \
     python -m pip install --no-cache-dir requests && \
     python -m pip install --no-cache-dir Jinja2 && \
     python -m pip cache purge
-RUN tfenv install 0.11.14 &&\
-    tfenv install 0.12.30 &&\
-    tfenv install 0.13.6 &&\
-    tfenv use 0.11.14
+RUN tfenv install 0.11.15 &&\
+    tfenv install 0.12.31 &&\
+    tfenv install 0.13.7 &&\
+    tfenv use 0.11.15
 COPY scripts/ /usr/local/bin/


### PR DESCRIPTION
# Description
## Background
HashiCorp was impacted by a security incident with a third party (Codecov) that led to potential disclosure of sensitive information. As a result, the GPG key used for release signing and verification has been rotated. Customers who verify HashiCorp release signatures may need to update their process to use the new key. Due to this event, hashicorp rotate their PGP key, and available on the latest version of terraform version, which is:
- 0.11.15
- 0.12.31
- 0.13.7

This PR is to update the terraform installed in terraform ci cd image to used the terraform version with the rotated PGP key.