### PR TITLE
handle inconsistency dependency lock file on Terraform v1.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/cache/* && \
     apt-get clean && \
     apt-get autoremove --purge
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+RUN apt-get install -y nodejs
 RUN locale-gen en_US.UTF-8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN git clone -b v2.2.2 https://github.com/tfutils/tfenv.git ~/.tfenv && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,10 @@ RUN python3 -m pip install --upgrade pip && \
 RUN tfenv install 0.11.15 &&\
     tfenv install 0.12.31 &&\
     tfenv install 0.13.7 &&\
-    tfenv install 1.0.3 &&\
+    tfenv install 1.0.11 &&\
     tfenv install 1.1.9 &&\
     tfenv install 1.2.9 &&\
-    tfenv install 1.3.6 &&\
+    tfenv install 1.3.7 &&\
     tfenv use 0.11.15
 
 # https://www.docker.com/blog/docker-can-now-run-within-docker/

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ RUN tfenv install 0.11.15 &&\
     tfenv install 0.13.7 &&\
     tfenv install 1.0.3 &&\
     tfenv install 1.1.9 &&\
+    tfenv install 1.2.9 &&\
+    tfenv install 1.3.6 &&\
     tfenv use 0.11.15
 
 # https://www.docker.com/blog/docker-can-now-run-within-docker/

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN tfenv install 0.11.15 &&\
     tfenv install 0.12.31 &&\
     tfenv install 0.13.7 &&\
     tfenv install 1.0.3 &&\
+    tfenv install 1.1.9 &&\
     tfenv use 0.11.15
 
 # https://www.docker.com/blog/docker-can-now-run-within-docker/

--- a/scripts/cd-do-terraform-apply.sh
+++ b/scripts/cd-do-terraform-apply.sh
@@ -40,7 +40,7 @@ if [ "$TF_WORKING_DIR" != "" ]; then
     # Save terraform apply stdout and stderr to temporary files
     # we need "bash" since codebuild will use "sh" as runtime
     # Update : https://aws.amazon.com/about-aws/whats-new/2020/06/aws-codebuild-now-supports-additional-shell-environments/
-    terraform init -no-color
+    terraform init -no-color -lockfile=readonly
     terraform apply terraform.tfplan -no-color > >(tee -a /tmp/tfApplyOutput) 2> >(tee -a /tmp/errMsg.log >&2)
     rm -rf .terraform
     cd -

--- a/scripts/cd-do-terraform-apply.sh
+++ b/scripts/cd-do-terraform-apply.sh
@@ -40,7 +40,11 @@ if [ "$TF_WORKING_DIR" != "" ]; then
     # Save terraform apply stdout and stderr to temporary files
     # we need "bash" since codebuild will use "sh" as runtime
     # Update : https://aws.amazon.com/about-aws/whats-new/2020/06/aws-codebuild-now-supports-additional-shell-environments/
-    terraform init -no-color -lockfile=readonly
+    if [[ $(terraform version | head -n 1 | grep -Eo "[.0-9]+") =~ ^1\..* ]]; then
+      terraform init -no-color -lockfile=readonly
+    else
+      terraform init -no-color
+    fi
     terraform apply terraform.tfplan -no-color > >(tee -a /tmp/tfApplyOutput) 2> >(tee -a /tmp/errMsg.log >&2)
     rm -rf .terraform
     cd -

--- a/scripts/ci-create-plan-artifact.sh
+++ b/scripts/ci-create-plan-artifact.sh
@@ -8,6 +8,7 @@ mkdir -p artifact/${TF_WORKING_DIR}
 if [ "$TF_WORKING_DIR" != "" ]; then
     cp -r ${TF_WORKING_DIR}/* artifact/${TF_WORKING_DIR}
     [[ -f ${TF_WORKING_DIR}/.terraform-version ]] && cp ${TF_WORKING_DIR}/.terraform-version artifact/${TF_WORKING_DIR}
+    [[ -f ${TF_WORKING_DIR}/.terraform.lock.hcl ]] && cp ${TF_WORKING_DIR}/.terraform.lock.hcl artifact/${TF_WORKING_DIR}
 fi
 # Create metadata.json file
 jq -n "{

--- a/scripts/ci-create-plan-artifact.sh
+++ b/scripts/ci-create-plan-artifact.sh
@@ -8,7 +8,7 @@ mkdir -p artifact/${TF_WORKING_DIR}
 if [ "$TF_WORKING_DIR" != "" ]; then
     cp -r ${TF_WORKING_DIR}/* artifact/${TF_WORKING_DIR}
     [[ -f ${TF_WORKING_DIR}/.terraform-version ]] && cp ${TF_WORKING_DIR}/.terraform-version artifact/${TF_WORKING_DIR}
-    [[ -f ${TF_WORKING_DIR}/.terraform.lock.hcl && -n $(git ls-tree -r HEAD~1 --name-only | grep "${TF_WORKING_DIR}/.terraform.lock.hcl") ]] && cp ${TF_WORKING_DIR}/.terraform.lock.hcl artifact/${TF_WORKING_DIR}
+    [[ -f ${TF_WORKING_DIR}/.terraform.lock.hcl ]] && cp ${TF_WORKING_DIR}/.terraform.lock.hcl artifact/${TF_WORKING_DIR}
 fi
 # Create metadata.json file
 jq -n "{

--- a/scripts/ci-create-plan-artifact.sh
+++ b/scripts/ci-create-plan-artifact.sh
@@ -8,7 +8,7 @@ mkdir -p artifact/${TF_WORKING_DIR}
 if [ "$TF_WORKING_DIR" != "" ]; then
     cp -r ${TF_WORKING_DIR}/* artifact/${TF_WORKING_DIR}
     [[ -f ${TF_WORKING_DIR}/.terraform-version ]] && cp ${TF_WORKING_DIR}/.terraform-version artifact/${TF_WORKING_DIR}
-    [[ -f ${TF_WORKING_DIR}/.terraform.lock.hcl ]] && cp ${TF_WORKING_DIR}/.terraform.lock.hcl artifact/${TF_WORKING_DIR}
+    [[ -f ${TF_WORKING_DIR}/.terraform.lock.hcl && -n $(git ls-tree -r HEAD~1 --name-only | grep "${TF_WORKING_DIR}/.terraform.lock.hcl") ]] && cp ${TF_WORKING_DIR}/.terraform.lock.hcl artifact/${TF_WORKING_DIR}
 fi
 # Create metadata.json file
 jq -n "{

--- a/scripts/ci-do-terraform-plan.sh
+++ b/scripts/ci-do-terraform-plan.sh
@@ -16,7 +16,6 @@ echo "Working dir : $TF_WORKING_DIR"
 mkdir -p artifact
 if [ "$TF_WORKING_DIR" != "" ]; then
     cd $TF_WORKING_DIR
-    
     if [[ $(terraform version | head -n 1 | grep -Eo "[.0-9]+") =~ ^1\..* ]]; then
       terraform init -no-color -lockfile=readonly 2> /tmp/errMsg.log
     else

--- a/scripts/ci-do-terraform-plan.sh
+++ b/scripts/ci-do-terraform-plan.sh
@@ -16,7 +16,7 @@ echo "Working dir : $TF_WORKING_DIR"
 mkdir -p artifact
 if [ "$TF_WORKING_DIR" != "" ]; then
     cd $TF_WORKING_DIR
-    terraform init -no-color 2> /tmp/errMsg.log
+    terraform init -no-color -lockfile=readonly 2> /tmp/errMsg.log
     terraform plan -out=terraform.tfplan -no-color 2> /tmp/errMsg.log
     cd -
 fi

--- a/scripts/ci-do-terraform-plan.sh
+++ b/scripts/ci-do-terraform-plan.sh
@@ -16,7 +16,12 @@ echo "Working dir : $TF_WORKING_DIR"
 mkdir -p artifact
 if [ "$TF_WORKING_DIR" != "" ]; then
     cd $TF_WORKING_DIR
-    terraform init -no-color -lockfile=readonly 2> /tmp/errMsg.log
+    
+    if [[ $(terraform version | head -n 1 | grep -Eo "[.0-9]+") =~ ^1\..* ]]; then
+      terraform init -no-color -lockfile=readonly 2> /tmp/errMsg.log
+    else
+      terraform init -no-color 2> /tmp/errMsg.log
+    fi
     terraform plan -out=terraform.tfplan -no-color 2> /tmp/errMsg.log
     cd -
 fi


### PR DESCRIPTION
## Problem

When we are running Terraform CI/CD with Terraform v1.x lockfile, sometimes the lockfile is not respected and we need to pin again manually using `required_providers {}` block. Turned out the `terraform.lock.hcl` is not copied.

```sh
[Container] 2022/10/02 03:08:51 Running command . ci-create-plan-artifact.sh
  adding: ap-southeast-1/ (stored 0%)
  adding: ap-southeast-1/ewlswgr/ (stored 0%)
  adding: ap-southeast-1/ewlswgr/00-terraform.tf (deflated 52%)
  adding: ap-southeast-1/ewlswgr/01-locals.tf (deflated 66%)
  adding: ap-southeast-1/ewlswgr/02-data.tf (deflated 67%)
  adding: ap-southeast-1/ewlswgr/03-security-group.tf (deflated 79%)
  adding: ap-southeast-1/ewlswgr/04-api-gateway.tf (deflated 64%)
  adding: ap-southeast-1/ewlswgr/05-iam.tf (deflated 53%)
  adding: ap-southeast-1/ewlswgr/06-authorizer.tf (deflated 61%)
  adding: ap-southeast-1/ewlswgr/07-swagger-ui.tf (deflated 62%)
  adding: ap-southeast-1/ewlswgr/08-route53.tf (deflated 49%)
  adding: ap-southeast-1/ewlswgr/09-outputs.tf (deflated 59%)
  adding: ap-southeast-1/ewlswgr/authorizer/ (stored 0%)
  adding: ap-southeast-1/ewlswgr/authorizer/main.py (deflated 63%)
  adding: ap-southeast-1/ewlswgr/authorizer.zip (stored 0%)
  adding: ap-southeast-1/ewlswgr/README.md (deflated 50%)
  adding: ap-southeast-1/ewlswgr/swagger-ui/ (stored 0%)
  adding: ap-southeast-1/ewlswgr/swagger-ui/.nvmrc (stored 0%)
  adding: ap-southeast-1/ewlswgr/swagger-ui/app.js (deflated 50%)
  adding: ap-southeast-1/ewlswgr/swagger-ui/local.js (deflated 10%)
  adding: ap-southeast-1/ewlswgr/swagger-ui/package-lock.json (deflated 66%)
  adding: ap-southeast-1/ewlswgr/swagger-ui/package.json (deflated 38%)
  adding: ap-southeast-1/ewlswgr/swagger-ui/serverless.js (deflated 27%)
  adding: ap-southeast-1/ewlswgr/terraform.tfplan (deflated 22%)
  adding: ap-southeast-1/ewlswgr/.terraform-version (stored 0%)
  adding: metadata.json (deflated 19%)
```

Additionally post v1.1 above, it also failed with the following message:

```sh
Error: Inconsistent dependency lock file

The given plan file was created with a different set of external dependency
selections than the current configuration. A saved plan can be applied only
to the same configuration it was created from.

Create a new plan from the updated configuration.
---
lines_history: [23 1 4 0]
function_trace: [failure source main]
exit_code: 1
source_trace:
  - /usr/local/bin/00_trap.sh
  - /usr/local/bin/cd-do-terraform-apply.sh
  - /codebuild/output/tmp/script.sh
last_command: . cd-do-terraform-apply.sh
```

## Solution

* check if `.terraform-lock.hcl` exist
* add `-lockfile=readonly` flag during `terraform init` based on this [StackOverflow](https://stackoverflow.com/a/70930940).